### PR TITLE
Bigger logo, smaller text

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         -o-transform: var(--scale);
         transform: var(--scale);
       }
-      h1 { font-size: var(--step-5); }
+      h1 { font-size: var(--step-4); }
       h2 { font-size: var(--step-2); }
       blockquote { font-style: italic; font-size: var(--step-1); margin-inline: 0; }
       blockquote cite { font-size: var(--step-0); }
@@ -46,7 +46,7 @@
       }
       main > * { grid-column: content; }
       #hero { grid-column-start: 1; grid-column-end: 4; }
-      #hero { display: flex; flex-direction: column; gap: 4vh; align-items: center; margin-block: 4vh; }
+      #hero { display: flex; flex-direction: column; gap: 15vh; align-items: center; margin-block: 4vh; }
       .flow > * + * {
         margin-block-start: var(--flow-space, 1em);
       }
@@ -56,7 +56,7 @@
     <main class="flow">
       <hgroup id="hero">
         <!-- <span style="font-size: calc(1.618 * var(--step-4));">♥</span> -->
-        <img src="heart.svg" title="♥" style="max-width: clamp(1rem, 4rem + 10vw, 20rem); max-height: 20vh;">
+        <img src="heart.svg" title="♥" style="max-width: clamp(1rem, 4rem + 12vw, 20rem); max-height: 80vh;">
         <h1>Act&nbsp;different.</h1>
       </hgroup>
     </main>


### PR DESCRIPTION
I have *no* idea what I'm doing with this CSS here, so please let me know if this doesn't make sense. Just trying to better emulate the original proportions.

Before:

<img width="896" alt="Screenshot 2025-02-20 at 6 53 17 AM" src="https://github.com/user-attachments/assets/1da65483-67ae-470b-8645-84b6fa9b5a13" />

After:

<img width="896" alt="Screenshot 2025-02-20 at 6 53 25 AM" src="https://github.com/user-attachments/assets/26ec9ab7-2ced-476a-a101-bc4547978482" />
