### PR TITLE
Responsive heart

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
       }
       main > * { grid-column: content; }
       #hero { grid-column-start: 1; grid-column-end: 4; }
-      #hero { display: flex; flex-direction: column; gap: 15vh; align-items: center; margin-block: 4vh; }
+      #hero { display: flex; flex-direction: column; gap: calc(var(--step-4) / 1.618); align-items: center; margin-block: 4vh; }
       .flow > * + * {
         margin-block-start: var(--flow-space, 1em);
       }

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
     <main class="flow">
       <hgroup id="hero">
         <!-- <span style="font-size: calc(1.618 * var(--step-4));">♥</span> -->
-        <img src="heart.svg" title="♥" style="max-width: clamp(1rem, 4rem + 12vw, 20rem); max-height: 80vh;">
+        <img src="heart.svg" title="♥" style="width: clamp(1rem, 4rem + 12vw, 20rem); max-height: clamp(2rem, 80vh, calc(2 * var(--step-4)));">
         <h1>Act&nbsp;different.</h1>
       </hgroup>
     </main>


### PR DESCRIPTION
With text in #7 I noticed some sizing oddities. 

This restores responsive heart graphics sizes (AFAIK one dimension needs to be set directly, not merely bounded with `max-`). 

Also makes the gap responsive.

Both react to the title font now so that they should remain in proportion

| Small | Medium | Large |
| -- | -- | -- |
| ![2025-02-22 06-15-06 Arc - Act different@2x](https://github.com/user-attachments/assets/d5ef1696-fe20-4712-9181-38fc2c7cf562) | ![2025-02-22 06-19-03 Arc - Act different@2x](https://github.com/user-attachments/assets/c97fdb62-f94e-4026-a738-f1baecb24f5f) | ![2025-02-22 06-18-41 Arc - Act different@2x](https://github.com/user-attachments/assets/aed1ecca-5da6-4f42-a8cb-df81895c4c57) |
